### PR TITLE
Added 2 tables: configuration of tx_monitor and state for tx-state pe…

### DIFF
--- a/common/schema.h
+++ b/common/schema.h
@@ -30,7 +30,7 @@ namespace swss {
 #define APP_FDB_TABLE_NAME                "FDB_TABLE"
 #define APP_PFC_WD_TABLE_NAME             "PFC_WD_TABLE"
 #define APP_SWITCH_TABLE_NAME             "SWITCH_TABLE"
-  
+
 #define APP_COPP_TABLE_NAME               "COPP_TABLE"
 #define APP_VRF_TABLE_NAME                "VRF_TABLE"
 #define APP_VNET_TABLE_NAME               "VNET_TABLE"
@@ -226,6 +226,8 @@ namespace swss {
 #define CFG_NAT_BINDINGS_TABLE_NAME                 "NAT_BINDINGS"
 #define CFG_NAT_GLOBAL_TABLE_NAME                   "NAT_GLOBAL"
 
+#define CFG_TX_MONITOR_TABLE_NAME                   "TX_MONITOR"
+
 /***** STATE DATABASE *****/
 
 #define STATE_SWITCH_CAPABILITY_TABLE_NAME          "SWITCH_CAPABILITY_TABLE"
@@ -246,6 +248,7 @@ namespace swss {
 #define STATE_BGP_TABLE_NAME                        "BGP_STATE_TABLE"
 #define STATE_DEBUG_COUNTER_CAPABILITIES_NAME       "DEBUG_COUNTER_CAPABILITIES"
 #define STATE_NAT_RESTORE_TABLE_NAME                "NAT_RESTORE_TABLE"
+#define STATE_PORT_TX_STATE_TABLE_NAME              "PORT_TX_STATE_TABLE"
 
 /***** MISC *****/
 


### PR DESCRIPTION
…r port

What I did
Added 2 new tables: One is related to Config DB, and the other to State DB.
The table added to configDB is called "TX_MONITOR" and its purpose is to hold the current configuration related to tx-monitor feature (timer interval and threshold).
The table added to stateDB is called "PORT_TX_STATE_TABLE" and its purpose is to hold the tx-state per port.

Why I did it
There was a need to save current configuration of tx monitor feature, and to save the tx-state per port.

How I verified it
Upload the version on switch and check the correlation between configuration, DB, etc.
In addition verify the data presented to the user by the cli-commands (which read it from the DBs).

Details if related


Signed-off-by: Noy Saban <noysa@nvidia.com>